### PR TITLE
changed sql types access to pub

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -13,4 +13,4 @@
 pub mod kv;
 /// SQL database module.
 pub mod sql;
-mod sql_types;
+pub mod sql_types;


### PR DESCRIPTION
the trait SqlTypes is not pub.

I needed to define a method parameter to values that have the SqlType trait but noticed that the sdk does not exposes the trait, making it impossible to do as I can not `use ws_sdk::database::sql_types::SqlType` 
